### PR TITLE
Add features

### DIFF
--- a/Mentions/build.gradle
+++ b/Mentions/build.gradle
@@ -1,13 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.0.5-2'
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Mentions/mentions/build.gradle
+++ b/Mentions/mentions/build.gradle
@@ -1,7 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'jacoco'
-apply plugin: 'com.github.dcendents.android-maven'
 
 group 'com.percolate.mentions'
 version '1.0-SNAPSHOT'
@@ -28,13 +25,6 @@ android {
             testCoverageEnabled false
         }
     }
-    testOptions {
-        unitTests.all {
-            jacoco {
-                includeNoLocationClasses = true
-            }
-        }
-    }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -44,41 +34,7 @@ repositories {
     mavenCentral()
 }
 
-jacoco {
-    version = '0.7.6.201602180812'
-}
-
-task coverage(type:JacocoReport, dependsOn: "testDebugUnitTest") {
-    group = "Reporting"
-    description = 'Create code coverage report for library.'
-
-    classDirectories = fileTree(
-            dir: "$buildDir/intermediates/classes/debug",
-            excludes: ['**/R.class',
-                       '**/R$*.class',
-                       '**/BuildConfig.*',
-                       'com/percolate/mentions/CharSequenceUtils.class',
-                       'com/percolate/mentions/StringUtils.class']
-    )
-
-    sourceDirectories = files("src/main/java")
-    executionData = files("build/jacoco/testDebugUnitTest.exec")
-
-    reports {
-        //noinspection GroovyAssignabilityCheck
-        xml.enabled = true
-    }
-}
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.0.1'
-
-    testCompile 'junit:junit:4.12'
-    testCompile "org.robolectric:robolectric:3.1.4"
-    testCompile 'org.mockito:mockito-core:2.2.28'
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
-    //Prevents class not found exception https://github.com/robolectric/robolectric/issues/1932
-    testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
 }

--- a/Mentions/mentions/build.gradle
+++ b/Mentions/mentions/build.gradle
@@ -28,6 +28,9 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 repositories {

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/MentionCheckerLogic.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/MentionCheckerLogic.java
@@ -1,5 +1,6 @@
 package com.percolate.mentions;
 
+import android.text.Editable;
 import android.widget.EditText;
 
 /**
@@ -28,7 +29,7 @@ class MentionCheckerLogic {
     void setMaxCharacters(final int maxCharacters) {
         if (maxCharacters <= 0) {
             throw new IllegalArgumentException("Maximum number of characters must be greater " +
-                                               "than 0.");
+                    "than 0.");
         }
         this.maxCharacters = maxCharacters;
     }
@@ -44,13 +45,23 @@ class MentionCheckerLogic {
      * @return String   A valid query that satisfies the three rules above.
      */
     String doMentionCheck() {
+        final String intput = editText.getText().toString();
+
         String queryToken = null;
 
         // perform a search if the {@link EditText} has an '@' symbol.
-        if (StringUtils.contains(editText.getText(), "@")) {
+        if (StringUtils.contains(intput, "@")) {
             final int cursorPosition = editText.getSelectionStart();
-            final String allTextBeforeCursor = editText.getText().toString().substring(0, cursorPosition);
-            final String providedSearchText = StringUtils.substringAfterLast(allTextBeforeCursor, "@");
+            final String allTextBeforeCursor = intput.substring(0, cursorPosition);
+            final String allTextAfterCursor = intput.substring(cursorPosition, intput.length());
+
+            // If the user tap in the middle of a word, the queryToken will include the
+            // full word. So we get the rest of the word until the end of the string
+            // or until we found a space
+            final String remainingWord = StringUtils.substringBefore(allTextAfterCursor, " ");
+            final String AllTextBeforeWithFullWord = allTextBeforeCursor + remainingWord;
+
+            final String providedSearchText = StringUtils.substringAfterLast(AllTextBeforeWithFullWord, "@");
 
             // check search text is within <code>maxCharacters</code> and begins with a
             // alpha numeric char.
@@ -128,10 +139,10 @@ class MentionCheckerLogic {
             //Multiple text is not highlighted
             if (editText.length() >= start) {
                 String text = editText.getText().toString().substring(0, start);
-                text = StringUtils.substringAfterLast(text, " ");
-                if (StringUtils.startsWith(text, "@")) {
-                    return true;
+                if(StringUtils.contains(text, " ")) {
+                    text = StringUtils.substringAfterLast(text, " ");
                 }
+                return StringUtils.startsWith(text, "@");
             }
         }
         return false;

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/MentionCheckerLogic.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/MentionCheckerLogic.java
@@ -44,7 +44,7 @@ class MentionCheckerLogic {
      * @return String   A valid query that satisfies the three rules above.
      */
     String doMentionCheck() {
-        String queryToken = "";
+        String queryToken = null;
 
         // perform a search if the {@link EditText} has an '@' symbol.
         if (StringUtils.contains(editText.getText(), "@")) {
@@ -101,7 +101,7 @@ class MentionCheckerLogic {
      * @return true or false
      */
     private boolean searchIsWithinMaxChars(final String providedSearchText, final int maxCharacters) {
-        return (providedSearchText.length() >= 1 && providedSearchText.length() <= maxCharacters);
+        return (providedSearchText.length() >= 0 && providedSearchText.length() <= maxCharacters);
     }
 
     /**
@@ -111,7 +111,7 @@ class MentionCheckerLogic {
      * @return true or false
      */
     private boolean searchBeginsWithAlphaNumericChar(final String providedSearchText) {
-        return Character.isLetterOrDigit(providedSearchText.charAt(0));
+        return providedSearchText.length() == 0 || Character.isLetterOrDigit(providedSearchText.charAt(0));
     }
 
     /**

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/MentionInsertionLogic.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/MentionInsertionLogic.java
@@ -82,18 +82,22 @@ class MentionInsertionLogic {
      *
      * @param mention Mentionable     A mention to display in {@link EditText}.
      */
-     void insertMention(final Mentionable mention) {
+    void insertMention(final Mentionable mention) {
         checkMentionable(mention);
         mention.setMentionLength(mention.getMentionName().length());
 
         final int cursorPosition = editText.getSelectionEnd();
         final String text = editText.getText().toString();
-        final String toReplace = text.substring(0, cursorPosition);
-        final int start = toReplace.lastIndexOf("@");
+        final String textBefore = text.substring(0, cursorPosition);
+        final int start = textBefore.lastIndexOf("@");
+        final String allTextAfterCursor = text.substring(cursorPosition, text.length());
+
+        final String remainingWord = StringUtils.substringBefore(allTextAfterCursor, " ");
+        final int deleteUntil = cursorPosition + remainingWord.length();
 
         if (start != -1) {
             final int newCursorPosition = start + mention.getMentionName().length() + 1;
-            editText.getText().delete(start, cursorPosition);
+            editText.getText().delete(start, deleteUntil);
             editText.getText().insert(start, mention.getMentionName() + " ");
 
             // Fix bug on LG G3 phone, where EditText messes up when using insert() method.
@@ -149,7 +153,7 @@ class MentionInsertionLogic {
      * @param after         int             The length of the new text entered by the user.
      */
     void checkIfProgrammaticallyClearedEditText(final CharSequence charSequence, final int start,
-            final int count, final int after) {
+                                                final int count, final int after) {
         if (StringUtils.isNotBlank(charSequence) && start == 0 && count == charSequence.length()
                 && after == 0) {
             mentions.clear();
@@ -166,7 +170,7 @@ class MentionInsertionLogic {
      * @param before int     Length of old text.
      * @param count  int     The number of characters in the new text.
      */
-     void updateInternalMentionsArray(final int start, final int before, final int count) {
+    void updateInternalMentionsArray(final int start, final int before, final int count) {
         if (!mentions.isEmpty()) {
             if (before != count) { // Text not changed if they ==.
                 for (Iterator<Mentionable> iterator = mentions.iterator(); iterator.hasNext(); ) {
@@ -223,7 +227,7 @@ class MentionInsertionLogic {
                     }
                 } catch (Exception ex) {
                     Log.e("Mentions", "Mention removed due to exception. + [" +
-                                                                mention.getMentionName() + "]", ex);
+                            mention.getMentionName() + "]", ex);
                     iterator.remove();
                 }
             }

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/Mentions.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/Mentions.java
@@ -48,6 +48,12 @@ public class Mentions {
     protected final MentionInsertionLogic mentionInsertionLogic;
 
     /**
+     * If true, suggestion will be displayed immediately when user insert @. Otherwise user has
+     * to key in at least @ + one alphanumeric character.
+     * Default value is false
+     */
+    protected boolean allowEmptyQuery;
+    /**
      * Pass in your {@link EditText} to give it the ability to @ mention.
 
      * @param context   Context     Although not used in the library, it passed for future use.
@@ -148,6 +154,18 @@ public class Mentions {
         }
 
         /**
+         * Set true if you want the suggestion immediately after user enter @
+         *
+         * @param allowEmptyQuery      Boolean       true if you allow empty query
+         *
+         */
+        public Builder allowEmptyQuery(final boolean allowEmptyQuery) {
+            mentionsLib.allowEmptyQuery = allowEmptyQuery;
+            return this;
+        }
+
+
+        /**
          * Builds and returns a {@link Mentions} object.
          */
         public Mentions build() {
@@ -239,11 +257,15 @@ public class Mentions {
      * @param query     String      A valid query.
      */
     public void queryReceived(final String query) {
-        if (queryListener != null && StringUtils.isNotBlank(query)) {
-            queryListener.onQueryReceived(query);
-        } else {
             suggestionsListener.displaySuggestions(false);
         }
+        final boolean show = allowEmptyQuery || StringUtils.isNotBlank(query);
+
+        if (show && queryListener != null) {
+            queryListener.onQueryReceived(query);
     }
 
+        if(suggestionsListener != null) {
+            suggestionsListener.displaySuggestions(show);
+        }
 }

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/Mentions.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/Mentions.java
@@ -53,6 +53,13 @@ public class Mentions {
      * Default value is false
      */
     protected boolean allowEmptyQuery;
+
+    /**
+     * If true, The suggestion will match all the words after @ sign.
+     * Otherwise the first word with match and adding a space will close the suggestion
+     */
+    protected boolean allowSpaceInQuery;
+
     /**
      * Pass in your {@link EditText} to give it the ability to @ mention.
 
@@ -94,6 +101,7 @@ public class Mentions {
                 throw new IllegalArgumentException("EditText must not be null.");
             }
             this.mentionsLib = new Mentions(context, editText);
+            this.mentionsLib.allowSpaceInQuery = true;
         }
 
         /**
@@ -161,6 +169,17 @@ public class Mentions {
          */
         public Builder allowEmptyQuery(final boolean allowEmptyQuery) {
             mentionsLib.allowEmptyQuery = allowEmptyQuery;
+            return this;
+        }
+
+        /**
+         * Set true If want to allow space to be part of the query
+         *
+         * @param allowSpaceInQuery      Boolean       true if you allow space in query
+         *
+         */
+        public Builder allowSpaceInQuery(final boolean allowSpaceInQuery) {
+            mentionsLib.allowSpaceInQuery = allowSpaceInQuery;
             return this;
         }
 
@@ -251,21 +270,28 @@ public class Mentions {
     }
 
     /**
-     * If the user typed a query that was valid then return it. Otherwise, notify you to close
+     * If the user typed a query that was valid then return it.
+     * Notify you to open or close base on the query and if you allow empty query
      * a suggestions list.
      *
      * @param query     String      A valid query.
      */
     public void queryReceived(final String query) {
-            suggestionsListener.displaySuggestions(false);
+        if(query == null || (!allowSpaceInQuery && StringUtils.contains(query, " "))) {
+            if(suggestionsListener != null) {
+                suggestionsListener.displaySuggestions(false);
+            }
+            return;
         }
+
         final boolean show = allowEmptyQuery || StringUtils.isNotBlank(query);
 
         if (show && queryListener != null) {
             queryListener.onQueryReceived(query);
-    }
+        }
 
         if(suggestionsListener != null) {
             suggestionsListener.displaySuggestions(show);
         }
+    }
 }

--- a/Mentions/mentions/src/main/java/com/percolate/mentions/StringUtils.java
+++ b/Mentions/mentions/src/main/java/com/percolate/mentions/StringUtils.java
@@ -286,6 +286,47 @@ class StringUtils {
     }
 
     /**
+     * <p>Gets the substring before the first occurrence of a separator.
+     * The separator is not returned.</p>
+     *
+     * <p>A {@code null} string input will return {@code null}.
+     * An empty ("") string input will return the empty string.
+     * A {@code null} separator will return the input string.</p>
+     *
+     * <p>If nothing is found, the string input is returned.</p>
+     *
+     * <pre>
+     * StringUtils.substringBefore(null, *)      = null
+     * StringUtils.substringBefore("", *)        = ""
+     * StringUtils.substringBefore("abc", "a")   = ""
+     * StringUtils.substringBefore("abcba", "b") = "a"
+     * StringUtils.substringBefore("abc", "c")   = "ab"
+     * StringUtils.substringBefore("abc", "d")   = "abc"
+     * StringUtils.substringBefore("abc", "")    = ""
+     * StringUtils.substringBefore("abc", null)  = "abc"
+     * </pre>
+     *
+     * @param str  the String to get a substring from, may be null
+     * @param separator  the String to search for, may be null
+     * @return the substring before the first occurrence of the separator,
+     *  {@code null} if null String input
+     * @since 2.0
+     */
+    public static String substringBefore(String str, String separator) {
+        if (isEmpty(str) || separator == null) {
+            return str;
+        }
+        if (separator.length() == 0) {
+            return EMPTY;
+        }
+        int pos = str.indexOf(separator);
+        if (pos == INDEX_NOT_FOUND) {
+            return str;
+        }
+        return str.substring(0, pos);
+    }
+
+    /**
      * <p>Checks if a CharSequence is empty ("") or null.</p>
      *
      * <pre>

--- a/Mentions/sample/src/main/java/com/percolate/mentions/sample/activities/MainActivity.java
+++ b/Mentions/sample/src/main/java/com/percolate/mentions/sample/activities/MainActivity.java
@@ -84,6 +84,7 @@ public class MainActivity extends AppCompatActivity implements QueryListener, Su
         mentions = new Mentions.Builder(this, commentField)
                 .suggestionsListener(this)
                 .queryListener(this)
+                .allowSpaceInQuery(false)
                 .build();
         mentionsLoaderUtils = new MentionsLoaderUtils(this);
     }


### PR DESCRIPTION
Hi,

I added new feature.

- Allow empty query
To fit my requirement, I want to display the suggestion immediately after the user key in '@'. In the previous version, the user as to key in at least '@' and another character to trigger the callback. 
If you enable allowEmptyQuery(true) by using the builder you will have this behaviour. To avoid any breaking changes, the default value is false. 

- Allow space in Query
When the user key in @first name, currently it will give the query "first name". But In my case, I would like that if the user key in a space after a mention it will close the suggestion. This can be enable allowSpaceInQuery(true) when using the builder. The default value is true to fit the current behaviour

Bug fix
Currently, If I key in '@firstname how are you' when I tap the middle of 'firstname' it will only match from the '@' to my cursor position. Now, If you tap in the middle of 'firstname' you will receive 'firstname' and not 'firstn' for example. The replacement works as well.

Feel free to merge, modify or reject those changes.
Lucas
